### PR TITLE
Add OpenSSL 1.0 formula

### DIFF
--- a/Formula/openssl@1.0.rb
+++ b/Formula/openssl@1.0.rb
@@ -1,0 +1,91 @@
+class OpensslAT10 < Formula
+  desc "SSL/TLS cryptography library"
+  homepage "https://openssl.org/"
+  url "https://www.openssl.org/source/openssl-1.0.2u.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2u.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz"
+  sha256 "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16"
+
+  keg_only :provided_by_macos,
+    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
+
+  def install
+    # OpenSSL will prefer the PERL environment variable if set over $PATH
+    # which can cause some odd edge cases & isn't intended. Unset for safety,
+    # along with perl modules in PERL5LIB.
+    ENV.delete("PERL")
+    ENV.delete("PERL5LIB")
+
+    ENV.deparallelize
+    args = %W[
+      --prefix=#{prefix}
+      --openssldir=#{openssldir}
+      no-ssl2
+      no-ssl3
+      no-zlib
+      shared
+      enable-cms
+      darwin64-x86_64-cc
+      enable-ec_nistp_64_gcc_128
+    ]
+    system "perl", "./Configure", *args
+    system "make", "depend"
+    system "make"
+    system "make", "test"
+    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
+  end
+
+  def openssldir
+    etc/"openssl"
+  end
+
+  def post_install
+    keychains = %w[
+      /System/Library/Keychains/SystemRootCertificates.keychain
+    ]
+
+    certs_list = `security find-certificate -a -p #{keychains.join(" ")}`
+    certs = certs_list.scan(
+      /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
+    )
+
+    valid_certs = certs.select do |cert|
+      IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
+        openssl_io.write(cert)
+        openssl_io.close_write
+      end
+
+      $CHILD_STATUS.success?
+    end
+
+    openssldir.mkpath
+    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n") << "\n")
+  end
+
+  def caveats
+    <<~EOS
+      A CA file has been bootstrapped using certificates from the SystemRoots
+      keychain. To add additional certificates (e.g. the certificates added in
+      the System keychain), place .pem files in
+        #{openssldir}/certs
+
+      and run
+        #{opt_bin}/c_rehash
+    EOS
+  end
+
+  test do
+    # Make sure the necessary .cnf file exists, otherwise OpenSSL gets moody.
+    assert_predicate HOMEBREW_PREFIX/"etc/openssl/openssl.cnf", :exist?,
+            "OpenSSL requires the .cnf file for some functionality"
+
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system "#{bin}/openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end


### PR DESCRIPTION
Some older Python versions don't compile with OpenSSL 1.1.