### PR TITLE
Update to Python 3.10.0a2

### DIFF
--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -1,8 +1,8 @@
 class PythonAT310 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url "https://www.python.org/ftp/python/3.10.0/Python-3.10.0a1.tar.xz"
-  sha256 "db739461233fc1c0c15ccf4e35455bedcc7524a086935e11404df9c05352a960"
+  url "https://www.python.org/ftp/python/3.10.0/Python-3.10.0a2.tar.xz"
+  sha256 "597e9ed606065ef6a49f47fb405d81981eae78054e0162c3165c58a48381857e"
   head "https://github.com/python/cpython.git", branch: "3.10"
 
   # setuptools remembers the build flags python is built with and uses them to

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ is symlinked to `${HOMEBREW_PREFIX:-/usr/local}/bin`.
 - 2.7 (2.7.18)
 - 3.5 (3.5.10)
 - 3.6 (3.6.12)
-- 3.10 (3.10.0a1)
+- 3.10 (3.10.0a2)
 
 ## License
 


### PR DESCRIPTION
> Major new features of the 3.10 series, compared to 3.9
> 
> Python 3.10 is still in development. This releasee, 3.10.0a2 is the second of six planned alpha releases. Alpha releases are intended to make it easier to test the current state of new features and bug fixes and to test the release process. During the alpha phase, features may be added up until the start of the beta phase (2021-05-03) and, if necessary, may be modified or deleted up until the release candidate phase (2021-10-04). Please keep in mind that this is a preview release and its use is not recommended for production environments.
> 
> Many new features for Python 3.10 are still being planned and written. Among the new major new features and changes so far:
> 
> PEP 623 -- Remove wstr from Unicode
> PEP 604 -- Allow writing union types as X | Y
> PEP 612 -- Parameter Specification Variables
> PEP 626 -- Precise line numbers for debugging and other tools.